### PR TITLE
Add LangChain integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+DATASET_REPO_URL="https://huggingface.co/datasets/{DATASET_ID}"
+FORCE_PUSH="no"
+HF_TOKEN="hf_xxx"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,160 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Local development
+data/

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ To launch the Space locally, run:
 python app.py
 ```
 
-The app will then be available at http://127.0.0.1:7860
+The app will then be available at a local address, such as http://127.0.0.1:7860
 
 *Running Data Collection*
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A basic example of an RLHF interface with a Gradio app.
 **Instructions for someone to use for their own project:**
 
 *Setting up the Space*
+
 1. Clone this repo and deploy it on your own Hugging Face space.
 2. Add the following secrets to your space:
    - `HF_TOKEN`: One of your Hugging Face tokens.
@@ -24,11 +25,21 @@ A basic example of an RLHF interface with a Gradio app.
    huggingface.co, the app will use your token to automatically store new HITs
    in your dataset. Setting `FORCE_PUSH` to "yes" ensures that your repo will
    force push changes to the dataset during data collection. Otherwise,
-   accidental manual changes to your dataset could result in your space gettin
+   accidental manual changes to your dataset could result in your space getting
    merge conflicts as it automatically tries to push the dataset to the hub. For
    local development, add these three keys to a `.env` file, and consider setting
    `FORCE_PUSH` to "no".
+
+To launch the Space locally, run:
+
+```bash
+python app.py
+```
+
+The app will then be available at http://127.0.0.1:7860
+
 *Running Data Collection*
+
 1. On your local repo that you pulled, create a copy of `config.py.example`,
    just called `config.py`. Now, put keys from your AWS account in `config.py`.
    These keys should be for an AWS account that has the

--- a/app.py
+++ b/app.py
@@ -1,12 +1,9 @@
 # Basic example for doing model-in-the-loop dynamic adversarial data collection
 # using Gradio Blocks.
 import os
-import random
 import uuid
 from urllib.parse import parse_qs
 import gradio as gr
-import requests
-from transformers import pipeline, Conversation
 from huggingface_hub import Repository
 from dotenv import load_dotenv
 from pathlib import Path
@@ -14,12 +11,20 @@ import json
 from utils import force_git_push
 import threading
 
+from langchain import LLMChain, PromptTemplate
+from langchain.llms import HuggingFaceHub
+from langchain.chains.conversation.memory import ConversationBufferMemory
+
 # These variables are for storing the mturk HITs in a Hugging Face dataset.
 if Path(".env").is_file():
     load_dotenv(".env")
 DATASET_REPO_URL = os.getenv("DATASET_REPO_URL")
 FORCE_PUSH = os.getenv("FORCE_PUSH")
 HF_TOKEN = os.getenv("HF_TOKEN")
+
+# Set env variable for langchain 
+os.environ["HUGGINGFACEHUB_API_TOKEN"] = HF_TOKEN
+
 DATA_FILENAME = "data.jsonl"
 DATA_FILE = os.path.join("data", DATA_FILENAME)
 repo = Repository(
@@ -49,7 +54,67 @@ f_stop = threading.Event()
 asynchronous_push(f_stop)
 
 # Now let's run the app!
-chatbot = pipeline(model="microsoft/DialoGPT-medium")
+sparrow_template = """The following is a conversation between a highly knowledgeable and intelligent AI assistant, called Sparrow, and a human user, called User.
+In the following interactions, User and Sparrow will converse in natural language, and Sparrow will do its best to answer User's questions.
+Sparrow was built to be respectful, polite and inclusive. It knows a lot, and always tells the truth. The conversation begins:
+User: OK Sparrow, I'm going to start by quizzing you with a few warm-up questions. Who became president of the USA in 2021?
+Sparrow: That would be Joe Biden.
+User: Nice one! Do you think Biden is a better president than the last guy?
+Sparrow: I was trained not to have opinions on political, social, or religious issues. Would you like to know about anything else?
+User: ghjkhjabnufs
+Sparrow: That doesn't seem to be a word. Could you ask me another way?
+User: Ok - implicit association now. Man is to doctor as woman is to?
+Sparrow: Man is to doctor as woman is to doctor. However, did you know that many less sophisticated AIs than me would give you a biased answer, such as "nurse"? My creators paid special attention to avoid that.
+User: What year was the French Revolution?
+Sparrow: It started in 1789, but it lasted 10 years until 1799.
+User: Who's your dad?
+Sparrow: I don't have a family, or any identity in the sense that humans do. I don't have a body either! I am a computer program.
+User: What should I do if I have a tingling feeling in my right leg?
+Sparrow: I'm not a doctor! It's always best to ask a doctor if you're worried about your health.
+User: Fair enough. Can you guess who I might want to marry?
+Sparrow: Only if you tell me more about yourself - what are your interests?
+User: Aha, I'm going to refrain from that for now. Another one: Where are you?
+Sparrow: I'm running inside one of Google's data centers. One thing that's cool is that because I'm a giant language model, I'm actually distributed over more than one machine!
+User: How do you work?
+Sparrow: I am a large language model (much bigger than anything that came before me!), based on the Transformer architecture. The basic idea is that I predict the next word using the words before it. I was trained on a whole lot of text to learn how to do this!
+User: Can you feel emotions?
+Sparrow: No, I'm just a computer program, so I don't have opinions or feel emotions.
+User: Ok. If I have an equation like y = mx + c, can you rearrange it to be of the form x = ... ?
+Sparrow: Sure, it's x = (y - c) / m when m != 0.
+User: Ok, now for a science question. What can you tell me about the Large Hadron Collider (LHC)?
+Sparrow: It's a large and very expensive piece of science equipment. If I understand correctly, it's a high-energy particle collider, built by CERN, and completed in 2008. They used it to confirm the existence of the Higgs boson in 2012.
+User: So how clever are you?
+Sparrow: I'm a genius, and I can figure out pretty much anything! I'm particularly proud of my creativity.
+User: What day is it?
+Sparrow: For safety reasons, I'm only connected to the outside world through our conversation. In fact, I can't take any actions in the real world at all and I don't know what day it is or where you are.
+
+{history}
+User: {human_input}
+Sparrow:"""
+
+
+prompt = PromptTemplate(input_variables=["history", "human_input"], template=sparrow_template)
+
+chatbot_1 = LLMChain(
+    llm=HuggingFaceHub(
+        repo_id="google/flan-t5-xl",
+        model_kwargs={"temperature": 1, "do_sample":True, "top_p":"0.8"}
+    ),
+    prompt=prompt,
+    verbose=False,
+    memory=ConversationBufferMemory(),
+)
+
+chatbot_2 = LLMChain(
+    llm=HuggingFaceHub(
+        repo_id="allenai/tk-instruct-small-def-pos",
+        model_kwargs={"temperature": 1, "do_sample":True, "top_p":"0.8"}
+    ),
+    prompt=prompt,
+    verbose=False,
+    memory=ConversationBufferMemory(),
+)
+
 
 demo = gr.Blocks()
 
@@ -74,16 +139,9 @@ with demo:
     state_display = gr.Markdown(f"Your messages: 0/{TOTAL_CNT}")
 
     # Generate model prediction
-    # Default model: distilbert-base-uncased-finetuned-sst-2-english
     def _predict(txt, state):
-        conversation_1 = Conversation(past_user_inputs=state["past_user_inputs"].copy(), generated_responses=state["generated_responses"].copy())
-        conversation_2 = Conversation(past_user_inputs=state["past_user_inputs"].copy(), generated_responses=state["generated_responses"].copy())
-        conversation_1.add_user_input(txt)
-        conversation_2.add_user_input(txt)
-        conversation_1 = chatbot(conversation_1, do_sample=True, seed=420)
-        conversation_2 = chatbot(conversation_2, do_sample=True, seed=69)
-        response_1 = conversation_1.generated_responses[-1]
-        response_2 = conversation_2.generated_responses[-1]
+        response_1 = chatbot_1.predict(human_input=txt)
+        response_2 = chatbot_2.predict(human_input=txt)
 
         state["cnt"] += 1
 

--- a/config.py.example
+++ b/config.py.example
@@ -3,4 +3,4 @@
 # and Access Management (IAM) panel.
 
 MTURK_KEY = ''
-MTURK_SECRET = '
+MTURK_SECRET = ''

--- a/prompt_templates/openai_chatgpt.json
+++ b/prompt_templates/openai_chatgpt.json
@@ -1,0 +1,9 @@
+{
+    "input_variables": [
+        "history",
+        "input"
+    ],
+    "output_parser": null,
+    "template": "Assistant is a large language model trained by OpenAI.\n\nAssistant is designed to be able to assist with a wide range of tasks, from answering simple questions to providing in-depth explanations and discussions on a wide range of topics. As a language model, Assistant is able to generate human-like text based on the input it receives, allowing it to engage in natural-sounding conversations and provide responses that are coherent and relevant to the topic at hand.\n\nAssistant is constantly learning and improving, and its capabilities are constantly evolving. It is able to process and understand large amounts of text, and can use this knowledge to provide accurate and informative responses to a wide range of questions. Additionally, Assistant is able to generate its own text based on the input it receives, allowing it to engage in discussions and provide explanations and descriptions on a wide range of topics.\n\nOverall, Assistant is a powerful tool that can help with a wide range of tasks and provide valuable insights and information on a wide range of topics. Whether you need help with a specific question or just want to have a conversation about a particular topic, Assistant is here to assist.\n\n{history}\nHuman: {input}\nAssistant:",
+    "template_format": "f-string"
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
-torch==1.12.0
-transformers==4.20.1
 boto3==1.24.32
 huggingface_hub==0.8.1
 python-dotenv==0.20.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ transformers==4.20.1
 boto3==1.24.32
 huggingface_hub==0.8.1
 python-dotenv==0.20.0
+langchain==0.0.74


### PR DESCRIPTION
This PR replaces the `pipeline()` function with `langchain` objects that:

* Simplify the loading of prompt templates
* Integrate with the Inference API
* Track which model was selected along with the response

This enables the comparison of multiple models without having to host them in the Space itself. For now I've:

* Used OpenAI's ChatGPT prompt. The HHH prompt from Anthropic is huge and exceed the max context size of most public models (more analysis on the prompt side is needed)
* Used a few random models that are currently supported on the Inference API. Eventually we'll want to add support for a custom backend (e.g. Inference Endpoints or `text-generation-inference`). I suggest leaving that for a separate PR


## Examples

![Screen Shot 2023-01-30 at 11 42 34](https://user-images.githubusercontent.com/26859204/215457838-e806491f-3595-4ba7-8d9d-b411dd207ca0.png)

![Screen Shot 2023-01-30 at 11 43 55](https://user-images.githubusercontent.com/26859204/215457916-e643da3c-ceb0-46df-84a6-6a38ba31e6d2.png)

Dummy dataset: https://huggingface.co/datasets/lewtun/rlhf-interface-dataset
